### PR TITLE
fix for s6-overlay-suexec: fatal: can only run as pid 1 error

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Allows you to connect multiple clients to one single modbus server. Usally one m
 The addon is only tested and compatible with hassio supervisor. 
 
 ## Installation
-[![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2FAkulatraxas%2Fha-modbusproxy)
-- Add This [Repository](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2FAkulatraxas%2Fha-modbusproxy) (Or click Button above) 
+[![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2FChristophCaina%2Fha-modbusproxy)
+- Add This [Repository](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2FChristophCaina%2Fha-modbusproxy) (Or click Button above) 
 - Install ModBusProxy from the Add-On Store
 
 ## Configuration

--- a/modbus-proxy/CHANGELOG.md
+++ b/modbus-proxy/CHANGELOG.md
@@ -2,5 +2,6 @@
 
 | Version    | Change                                                    |
 | ---------- | --------------------------------------------------------- |
+| 1.0.13     | fixed issue s6-overlay-suexec: fatal: can only run as pid 1 |
 | 1.0.12     | Indentation error in config.yaml fixed                    |
 | 1.0.11     | Release Version. Packaged modbusproxy +  README and Logo  |

--- a/modbus-proxy/config.yaml
+++ b/modbus-proxy/config.yaml
@@ -9,6 +9,7 @@ arch:
   - armv7
 url: "https://community.home-assistant.io/t/updated-solaredge-modbus-full-setup-guide-with-energy-dashboard-integration-for-installations-with-battery-connected/340956/216?u=akulatraxas"
 startup: services
+init: false
 options:
   upstreamhost: "192.168.178.74"
   upstreamport: 502

--- a/modbus-proxy/config.yaml
+++ b/modbus-proxy/config.yaml
@@ -1,6 +1,6 @@
 name: "modbus-proxy"
 description: "Proxy for Accessing modbus systems. Allows multiple client connections"
-version: "1.0.12"
+version: "1.0.13"
 slug: "modbus_proxy"
 arch:
   - aarch64


### PR DESCRIPTION
Hi,
it seems that I was able to fix the above s6 error when the addon will be started.
It was required to add the "init: false" statement to the config.yaml.

I'Ve changed the repository path in order to install this addon in my HomeAssistant installation and for testing... maybe, you can discard that file.

fixed #3 