### PR TITLE
Feature: added timeout, connectiontime and log options

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -2,7 +2,7 @@
   "name": "Example devcontainer for add-on repositories",
   "image": "ghcr.io/home-assistant/devcontainer:addons",
   "appPort": ["7123:8123", "7357:4357"],
-  "postStartCommand": "bash devcontainer_bootstrap",
+  "postStartCommand": "sudo -E bash devcontainer_bootstrap",
   "runArgs": ["-e", "GIT_EDITOR=code --wait", "--privileged"],
   "containerEnv": {
     "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
       {
         "label": "Start Home Assistant",
         "type": "shell",
-        "command": "supervisor_run",
+        "command": "sudo chmod a+x /usr/bin/supervisor* && sudo -E supervisor_run",
         "group": {
           "kind": "test",
           "isDefault": true
@@ -17,4 +17,3 @@
       }
     ]
   }
-  

--- a/modbus-proxy/config.yaml
+++ b/modbus-proxy/config.yaml
@@ -1,6 +1,6 @@
 name: "modbus-proxy"
 description: "Proxy for Accessing modbus systems. Allows multiple client connections"
-version: "1.0.13"
+version: "1.0.14"
 slug: "modbus_proxy"
 arch:
   - aarch64
@@ -14,9 +14,15 @@ options:
   upstreamhost: "192.168.178.74"
   upstreamport: 502
   listenport: 502
+  connecttime: 0.1
+  timeout: 10
+  loglevel: "INFO"
 schema:
   upstreamhost: str
   upstreamport: int
   listenport: int
+  connecttime: float
+  timeout: int
+  loglevel: list(INFO|DEBUG|ERROR)
 ports:
   502/tcp: 502

--- a/modbus-proxy/rootfs/srv/modbus.config.yaml
+++ b/modbus-proxy/rootfs/srv/modbus.config.yaml
@@ -1,7 +1,19 @@
 devices:
   - modbus:
       url: __HOST__:__PORT__ # device url (mandatory)
-      timeout: 10 # communication timeout (s) (optional, default: 10)
-      connection_time: 0.1 # delay after connection (s) (optional, default: 0)
+      timeout: __TIMEOUT__ # communication timeout (s) (optional, default: 10)
+      connection_time: __CONNECTIONTIME__ # delay after connection (s) (optional, default: 0)
     listen:
       bind: 0:__LISTENPORT__ # listening address (mandatory)
+logging:
+  version: 1
+  formatters:
+    standard:
+      format: "%(asctime)s %(levelname)8s %(name)s: %(message)s"
+  handlers:
+    console:
+      class: logging.StreamHandler
+      formatter: standard
+  root:
+    handlers: ['console']
+    level: __LOGLEVEL__

--- a/modbus-proxy/run.sh
+++ b/modbus-proxy/run.sh
@@ -4,14 +4,24 @@
 CONFIG_HOST=$(bashio::config 'upstreamhost')
 CONFIG_PORT=$(bashio::config 'upstreamport')
 CONFIG_LISTENPORT=$(bashio::config 'listenport')
+CONFIG_TIMEOUT=$(bashio::config 'timeout')
+CONFIG_CONNECTIONTIME=$(bashio::config 'connection_time')
+CONFIG_LOGLEVEL=$(bashio::config 'loglevel')
+
 
 echo "Preparing to run modbus-proxy"
 echo "Upstream: $CONFIG_HOST:$CONFIG_PORT"
 echo "Listen: $CONFIG_LISTENPORT"
+echo "Timeout: $CONFIG_TIMEOUT"
+echo "Connection Time: $CONFIG_CONNECTIONTIME"
+echo "Loglevel: $CONFIG_LOGLEVEL"
 
 sed -i "s/__HOST__/${CONFIG_HOST}/g" ./modbus.config.yaml
 sed -i "s/__PORT__/${CONFIG_PORT}/g" ./modbus.config.yaml
 sed -i "s/__LISTENPORT__/${CONFIG_LISTENPORT}/g" ./modbus.config.yaml
+sed -i "s/__TIMEOUT__/${CONFIG_TIMEOUT}/g" ./modbus.config.yaml
+sed -i "s/__CONNECTIONTIME__/${CONFIG_CONNECTIONTIME}/g" ./modbus.config.yaml
+sed -i "s/__LOGLEVEL__/${CONFIG_LOGLEVEL}/g" ./modbus.config.yaml
 
 echo "Generated Config"
 cat ./modbus.config.yaml

--- a/modbus-proxy/src/modbus_proxy.py
+++ b/modbus-proxy/src/modbus_proxy.py
@@ -64,7 +64,7 @@ class Connection:
 
     async def close(self):
         if self.writer is not None:
-            self.log.info("closing connection...")
+            self.log.debug("closing connection...")
             try:
                 self.writer.close()
                 await self.writer.wait_closed()
@@ -117,7 +117,7 @@ class Client(Connection):
     def __init__(self, reader, writer):
         peer = writer.get_extra_info("peername")
         super().__init__(f"Client({peer[0]}:{peer[1]})", reader, writer)
-        self.log.info("new client connection")
+        self.log.debug("new client connection")
 
 
 class ModBus(Connection):


### PR DESCRIPTION
New Options:
- timeout: communication timeout (s)
- connectiontime: delay after connection (s)
- loglevel: INFO|ERROR|DEBUG

The default loglevel will not longer log connections to avoid unessesary write load to the storage.
Raise to level DEBUG if you want to see them.