### PR TITLE
Remove armhf and armv7 architectures from config

### DIFF
--- a/modbus-proxy/config.yaml
+++ b/modbus-proxy/config.yaml
@@ -5,8 +5,6 @@ slug: "modbus_proxy"
 arch:
   - aarch64
   - amd64
-  - armhf
-  - armv7
 url: "https://community.home-assistant.io/t/updated-solaredge-modbus-full-setup-guide-with-energy-dashboard-integration-for-installations-with-battery-connected/340956/216?u=akulatraxas"
 startup: services
 init: false


### PR DESCRIPTION
Removed unsupported architectures from config.
If necessary we can probably build and push an "old" image for those still on these, but rebuilding on install is no longer possible